### PR TITLE
added converter.insertFoundDomains property

### DIFF
--- a/content/1_overview/04_configuring.md
+++ b/content/1_overview/04_configuring.md
@@ -88,7 +88,13 @@ Of principal importance when configuring the system is `conf/properties/system.p
 | converter.sideloadThreshold | integer | Threshold value, in number of documents per domain, where a simpler processing method is used which uses less RAM.  10,000 is a good value for ~32GB RAM |
 | converter.poolSize | integer | Number of threads used by the converter process, should probably be in the range 2 - 32                                                                  |
 | converter.lenientProcessing | boolean | Disable language, quality and length checks |
-| converter.insertFoundDomains | boolean | inserts all domains found in the crawl data into the database (defaults to true) |
+
+### Loader Properties
+
+| flag                        | values     | description                                                                                                                                              |
+|-----------------------------|------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| loader.insertFoundDomains | boolean | inserts all domains found in the crawl data into the database (defaults to true) |
+
 
 ### Marginalia Application Specific
 

--- a/content/1_overview/04_configuring.md
+++ b/content/1_overview/04_configuring.md
@@ -88,6 +88,7 @@ Of principal importance when configuring the system is `conf/properties/system.p
 | converter.sideloadThreshold | integer | Threshold value, in number of documents per domain, where a simpler processing method is used which uses less RAM.  10,000 is a good value for ~32GB RAM |
 | converter.poolSize | integer | Number of threads used by the converter process, should probably be in the range 2 - 32                                                                  |
 | converter.lenientProcessing | boolean | Disable language, quality and length checks |
+| converter.insertFoundDomains | boolean | inserts all domains found in the crawl data into the database (defaults to true) |
 
 ### Marginalia Application Specific
 


### PR DESCRIPTION
This adds the property 'converter.insertFoundDomains', which can be set in the system.properties file; it defaults to 'true'.

If set to 'false', it will prevent the processor from adding found domains to the database.

This change has PRs both on the main MargialiaSearch repo and the docs.marginalia.nu repo.